### PR TITLE
Corrected wrong conversion factor for UV index

### DIFF
--- a/DFRobot_VEML6075.h
+++ b/DFRobot_VEML6075.h
@@ -15,7 +15,12 @@
 #define UVI_VERY_HIGH   10.0f
 #define UVI_EXTREME     12.0f
 
-#define Uvi2mwpcm2(UVI) (UVI * 2500.0f)
+/* Conversion from UV index to mW/cm^2
+   using CIE-weighted UV
+   1 UV index = 25 mW/m^2 = 0.0025 mW/cm^2
+   Author:  @thedonator (Github)
+*/
+#define Uvi2mwpcm2(UVI) (UVI * 0.0025f)
 
 // registers ---------------------------------------------------------------
 


### PR DESCRIPTION
Corrected conversion `Uvi2mwpcm2(UVI)` because the wanted data needs to be converted from UV index to mW/cm^2.
Using CIE-weighted UV conversion we know that  `1 UV index = 25 mW/m^2 = 0.0025 mW/cm^2 `